### PR TITLE
kafkaGTMIP -> kafkaGTMIPList 

### DIFF
--- a/src/main/java/com/microsoft/kafkaavailability/properties/AppProperties.java
+++ b/src/main/java/com/microsoft/kafkaavailability/properties/AppProperties.java
@@ -14,7 +14,7 @@ public class AppProperties
     public String environmentName;
     public String sqlConnectionString;
     public boolean reportKafkaGTMAvailability;
-    public List<String> kafkaGTMIP;
+    public String kafkaGTMIPList;
     public boolean sendProducerAvailability;
     public boolean sendConsumerAvailability;
     public boolean sendProducerTopicAvailability;

--- a/src/main/java/com/microsoft/kafkaavailability/properties/AppProperties.java
+++ b/src/main/java/com/microsoft/kafkaavailability/properties/AppProperties.java
@@ -14,7 +14,7 @@ public class AppProperties
     public String environmentName;
     public String sqlConnectionString;
     public boolean reportKafkaGTMAvailability;
-    public String kafkaGTMIPList;
+    public String kafkaGTMIP;
     public boolean sendProducerAvailability;
     public boolean sendConsumerAvailability;
     public boolean sendProducerTopicAvailability;

--- a/src/main/java/com/microsoft/kafkaavailability/threads/AvailabilityThread.java
+++ b/src/main/java/com/microsoft/kafkaavailability/threads/AvailabilityThread.java
@@ -25,6 +25,7 @@ import org.slf4j.LoggerFactory;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Arrays;
 import java.util.concurrent.Phaser;
 
 import static com.microsoft.kafkaavailability.discovery.Constants.DEFAULT_ELAPSED_TIME;
@@ -113,9 +114,11 @@ public class AvailabilityThread implements Runnable {
         int failureThreshold = 10;
 
         List<String> gtmList = new ArrayList<String>();
-        if (!appProperties.kafkaGTMIP.isEmpty()) {
-            gtmList.addAll(appProperties.kafkaGTMIP);
+        String[] gtmArray = appProperties.kafkaGTMIPList.split(",");
+        if(!(gtmArray.length == 0)) {
+            gtmList.addAll(Arrays.asList(gtmArray));
         }
+
 
         //This is full list of topics
         List<TopicMetadata> totalTopicMetadata = metaDataManager.getAllTopicPartition();
@@ -136,7 +139,7 @@ public class AvailabilityThread implements Runnable {
         Histogram histogramGTMAvailabilityLatency = new Histogram(gtmAvailabilityLatencyWindow);
         MetricNameEncoded gtmAvailabilityLatency = new MetricNameEncoded("KafkaGTMIP.Availability.Latency", "all");
         if (!metrics.getNames().contains(new Gson().toJson(gtmAvailabilityLatency))) {
-            if (appProperties.sendGTMAvailabilityLatency && !appProperties.kafkaGTMIP.isEmpty())
+            if (appProperties.sendGTMAvailabilityLatency && !gtmList.isEmpty())
                 metrics.register(new Gson().toJson(gtmAvailabilityLatency), histogramGTMAvailabilityLatency);
         }
 
@@ -172,7 +175,7 @@ public class AvailabilityThread implements Runnable {
         }
 
         m_logger.info("done with VIP prop check.");
-        if (appProperties.reportKafkaGTMAvailability && !appProperties.kafkaGTMIP.isEmpty()) {
+        if (appProperties.reportKafkaGTMAvailability && !gtmList.isEmpty()) {
             m_logger.info("About to report kafkaGTMIPAvailability-- TryCount:" + gtmIPStatusTryCount + " FailCount:" + gtmIPStatusFailCount);
             MetricNameEncoded kafkaGTMIPAvailability = new MetricNameEncoded("KafkaGTMIP.Availability", "all");
             if (!metrics.getNames().contains(new Gson().toJson(kafkaGTMIPAvailability))) {

--- a/src/main/java/com/microsoft/kafkaavailability/threads/AvailabilityThread.java
+++ b/src/main/java/com/microsoft/kafkaavailability/threads/AvailabilityThread.java
@@ -114,7 +114,7 @@ public class AvailabilityThread implements Runnable {
         int failureThreshold = 10;
 
         List<String> gtmList = new ArrayList<String>();
-        String[] gtmArray = appProperties.kafkaGTMIPList.split(",");
+        String[] gtmArray = appProperties.kafkaGTMIP.split(",");
         if(!(gtmArray.length == 0)) {
             gtmList.addAll(Arrays.asList(gtmArray));
         }

--- a/src/main/resources/appProperties.json
+++ b/src/main/resources/appProperties.json
@@ -2,7 +2,7 @@
   "environmentName": "localhost",
   "sqlConnectionString": "jdbc:sqlserver://test;DatabaseName=test;lockTimeout=30000;loginTimeout=30000;user=test;password=test",
   "reportKafkaGTMAvailability": true,
-  "kafkaGTMIPList":"https://myTestEndpoint001.trafficmanager.net?topic=,https://myTestEndpoint002.trafficmanager.net?topic=",
+  "kafkaGTMIP":"https://myTestEndpoint001.trafficmanager.net?topic=,https://myTestEndpoint002.trafficmanager.net?topic=",
   "sendProducerAvailability": true,
   "sendConsumerAvailability": true,
   "sendProducerTopicAvailability": true,

--- a/src/main/resources/appProperties.json
+++ b/src/main/resources/appProperties.json
@@ -2,7 +2,7 @@
   "environmentName": "localhost",
   "sqlConnectionString": "jdbc:sqlserver://test;DatabaseName=test;lockTimeout=30000;loginTimeout=30000;user=test;password=test",
   "reportKafkaGTMAvailability": true,
-  "kafkaGTMIP":["https://myTestEndpoint001.trafficmanager.net?topic=","https://myTestEndpoint002.trafficmanager.net?topic="],
+  "kafkaGTMIPList":"https://myTestEndpoint001.trafficmanager.net?topic=,https://myTestEndpoint002.trafficmanager.net?topic=",
   "sendProducerAvailability": true,
   "sendConsumerAvailability": true,
   "sendProducerTopicAvailability": true,


### PR DESCRIPTION
due to the way deployemnts work, there isn't currently support for a custom setting that isn't a string. Rewriting to have kafkaGTMIPList as a string as opposed to an actual list